### PR TITLE
Fix album fetch to refresh OAuth token

### DIFF
--- a/src/app/flickr.main.ts
+++ b/src/app/flickr.main.ts
@@ -153,11 +153,18 @@ async function flickr(method: string, params: Record<string, string | number>) {
 
 // ====== High-level API ======
 export async function getAlbums(page = 1, perPage = 24): Promise<AlbumsPage> {
-  const token = readToken();
-  if (!token?.user_nsid) await ensureLogin();
+  let token = readToken();
+  if (!token?.user_nsid) {
+    token = await ensureLogin();
+    if (!token?.user_nsid) {
+      token = readToken();
+    }
+  }
+
+  if (!token?.user_nsid) throw new Error("Failed to obtain Flickr user id");
 
   const data = await flickr("flickr.photosets.getList", {
-    user_id: token!.user_nsid!,
+    user_id: token.user_nsid,
     page,
     per_page: perPage
   });


### PR DESCRIPTION
## Summary
- refresh the cached OAuth token when album retrieval triggers a login
- ensure the user id from the refreshed token is used for the photoset list request

## Testing
- not run (login flow requires external interaction)


------
https://chatgpt.com/codex/tasks/task_e_68dedc52b144833083158e1a52a7de76