### PR TITLE
Add window typings for exposed bulkflick preload API

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,16 @@
+import type { AlbumsPage, DownloadImage, SizePref } from "../app/types";
+
+declare global {
+  interface Window {
+    bulkflick: {
+      version: string;
+      authStatus: () => Promise<{ token: boolean }>;
+      login: () => Promise<{ ok: boolean; user?: unknown }>;
+      logout: () => Promise<{ ok: boolean }>;
+      getAlbums: (page?: number, perPage?: number) => Promise<AlbumsPage>;
+      getAlbumPhotos: (photosetId: string, size: SizePref) => Promise<DownloadImage[]>;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a renderer declaration file that augments `window` with the `bulkflick` preload surface
- rely on the shared app types so the preload bridge stays strongly typed

## Testing
- npx tsc --noEmit --project tsconfig.json *(fails: missing Node/Electron type declarations in main-process files, pre-existing)*

------
https://chatgpt.com/codex/tasks/task_e_68dedc5ca15083308a44f72c79651fd5