### PR TITLE
Add window typings for bulkflick preload API

### DIFF
--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -1,0 +1,16 @@
+import type { AlbumsPage, DownloadImage, SizePref } from "../app/types";
+
+declare global {
+  interface Window {
+    bulkflick: {
+      version: string;
+      authStatus: () => Promise<{ token: boolean }>;
+      login: () => Promise<{ ok: boolean; user?: unknown }>;
+      logout: () => Promise<{ ok: boolean }>;
+      getAlbums: (page?: number, perPage?: number) => Promise<AlbumsPage>;
+      getAlbumPhotos: (photosetId: string, size: SizePref) => Promise<DownloadImage[]>;
+    };
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a renderer declaration file that augments the Window interface with the bulkflick API exposed in preload.ts
- include the existing albums/photo types so the renderer can use strong typings for IPC calls

## Testing
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68dedc5d65308330840dc24ff8e6e274