### PR TITLE
Add Flickr API credentials

### DIFF
--- a/dist/app/flickr.main.js
+++ b/dist/app/flickr.main.js
@@ -8,8 +8,8 @@ const FLICKR_BASE = "https://www.flickr.com/services";
 const REST = "https://api.flickr.com/services/rest/";
 // NOTE: Put your keys here for local dev; later load from env/secure store.
 const FLICKR = {
-    apiKey: process.env.FLICKR_API_KEY ?? "<YOUR_FLICKR_API_KEY>",
-    apiSecret: process.env.FLICKR_API_SECRET ?? "<YOUR_FLICKR_API_SECRET>"
+    apiKey: process.env.FLICKR_API_KEY ?? "4718b07806e88233ce47ee5f53e744be",
+    apiSecret: process.env.FLICKR_API_SECRET ?? "7d2806f617398732"
 };
 // ====== OAuth 1.0a utils ======
 function percent(v) {

--- a/src/app/flickr.main.ts
+++ b/src/app/flickr.main.ts
@@ -11,8 +11,8 @@ const REST = "https://api.flickr.com/services/rest/";
 
 // NOTE: Put your keys here for local dev; later load from env/secure store.
 const FLICKR: FlickrSecrets = {
-  apiKey: process.env.FLICKR_API_KEY ?? "<YOUR_FLICKR_API_KEY>",
-  apiSecret: process.env.FLICKR_API_SECRET ?? "<YOUR_FLICKR_API_SECRET>"
+  apiKey: process.env.FLICKR_API_KEY ?? "4718b07806e88233ce47ee5f53e744be",
+  apiSecret: process.env.FLICKR_API_SECRET ?? "7d2806f617398732"
 };
 
 // ====== OAuth 1.0a utils ======


### PR DESCRIPTION
## Summary
- set default Flickr API key and secret to the provided credentials in the main process source
- mirror the credential defaults in the built distribution output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dedec0247c8330b9a0c8457d14acb5