### PR TITLE
Remove unused downloader and Flickr API modules

### DIFF
--- a/dist/app/downloader.js
+++ b/dist/app/downloader.js
@@ -1,4 +1,0 @@
-// Future: queue + concurrency control, resuming, checksum, etc.
-export async function enqueue(_jobUrl) {
-    /* stub */
-}

--- a/dist/app/flickr.api.js
+++ b/dist/app/flickr.api.js
@@ -1,6 +1,0 @@
-// Future: implement auth + album parsing.
-// Keep network code in renderer sandbox by proxying via main through IPC.
-export async function parseAlbumUrl(_url) {
-    // Placeholder
-    return { title: "Example Album", owner: "example", photoCount: 0 };
-}

--- a/src/app/downloader.ts
+++ b/src/app/downloader.ts
@@ -1,4 +1,0 @@
-// Future: queue + concurrency control, resuming, checksum, etc.
-export async function enqueue(_jobUrl: string) {
-  /* stub */
-}

--- a/src/app/flickr.api.ts
+++ b/src/app/flickr.api.ts
@@ -1,6 +1,0 @@
-// Future: implement auth + album parsing.
-// Keep network code in renderer sandbox by proxying via main through IPC.
-export async function parseAlbumUrl(_url: string) {
-  // Placeholder
-  return { title: "Example Album", owner: "example", photoCount: 0 };
-}


### PR DESCRIPTION
## Summary
- delete the unused downloader and Flickr API source files
- remove the corresponding generated JavaScript artifacts from the dist bundle

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dee0ba8f6883309870501a3d04c79f