### PR TITLE
Register bulkflick protocol as privileged scheme

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, ipcMain, Menu } from "electron";
+import { app, BrowserWindow, ipcMain, Menu, protocol } from "electron";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { ensureLogin, getAlbums, getAlbumPhotos } from "./app/flickr.main.js";
@@ -6,6 +6,13 @@ import { readToken, clearToken } from "./app/secure-store.js";
 import type { SizePref } from "./app/types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "bulkflick",
+    privileges: { standard: true, secure: true, supportFetchAPI: true }
+  }
+]);
 
 async function createWindow() {
   const win = new BrowserWindow({


### PR DESCRIPTION
## Summary
- import Electron's protocol module and register the bulkflick custom scheme as privileged so it can be used as an OAuth callback

## Testing
- npm install *(fails: 403 Forbidden when fetching electron from the registry in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def2315dd8833081a95aa810d22db3