### PR TITLE
Fix Flickr OAuth session usage

### DIFF
--- a/dist/app/flickr.main.js
+++ b/dist/app/flickr.main.js
@@ -1,5 +1,5 @@
 import crypto from "node:crypto";
-import { BrowserWindow, session } from "electron";
+import { BrowserWindow } from "electron";
 import { URLSearchParams } from "node:url";
 import { readToken, writeToken } from "./secure-store.js";
 // ====== CONFIG ======
@@ -78,7 +78,7 @@ export async function ensureLogin(parent) {
     });
     popup.removeMenu?.();
     await popup.loadURL(authUrl);
-    const ses = session.fromPartition(popup.webContents.getWebPreferences().partition || "");
+    const ses = popup.webContents.session;
     const verifier = await new Promise((resolve, reject) => {
         const handler = (details) => {
             if (details.url.startsWith(CALLBACK_SCHEME)) {

--- a/src/types/shims.d.ts
+++ b/src/types/shims.d.ts
@@ -54,9 +54,16 @@ declare module "electron" {
     webPreferences?: Record<string, unknown>;
   }
 
+  export interface WebRequest {
+    onBeforeRequest(filter: unknown, listener?: (details: any) => void): void;
+  }
+
   export class WebContents {
     getWebPreferences(): { partition?: string };
     openDevTools(options?: unknown): void;
+    readonly session: {
+      webRequest: WebRequest;
+    };
   }
 
   export class BrowserWindow {
@@ -83,9 +90,7 @@ declare module "electron" {
 
   export const session: {
     fromPartition(partition: string): {
-      webRequest: {
-        onBeforeRequest(filter: unknown, listener?: (details: any) => void): void;
-      };
+      webRequest: WebRequest;
     };
   };
 


### PR DESCRIPTION
## Summary
- extend the Electron WebContents shim so the OAuth flow can access the attached session
- rebuild the compiled Flickr main script so it uses popup.webContents.session during login

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68def238a65483309f2951159afc2c80