### PR TITLE
Allow Flickr images in CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8" />
   <meta
     http-equiv="Content-Security-Policy"
-    content="default-src 'self'; img-src 'self' data: blob:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self';"
+    content="default-src 'self'; img-src 'self' data: blob: https://*.staticflickr.com https://live.staticflickr.com; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self';"
   />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>BulkFlick</title>


### PR DESCRIPTION
## Summary
- broaden the CSP img-src directive to permit images hosted on Flickr's static CDN

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dff5213394833096325569c3505b9c